### PR TITLE
fix: update date formatting to include timezone offset

### DIFF
--- a/lib/utils/date.ts
+++ b/lib/utils/date.ts
@@ -8,7 +8,7 @@ export const baseInputDateFormat = (date: string | Date) =>
 	date ? format(date, 'yyyy-MM-dd') : null;
 
 export const baseDateTimeFormat = (date: string | Date) =>
-	date ? format(date, 'dd-MM-yyyy hh:mm:ss a') : null;
+	date ? format(date, 'dd-MM-yyyy hh:mm:ss a XXX') : null;
 
 export const stringToNewDate = (date: string) =>
 	new Date(date?.split('-').reverse().join(',')) ?? date ?? null;


### PR DESCRIPTION
- Modified baseDateTimeFormat to append timezone offset (XXX) to the formatted date string.
- Ensured that date formatting remains consistent and informative for better clarity in time representation.